### PR TITLE
Add automatic APK build workflow

### DIFF
--- a/.github/workflows/build_apk.yml
+++ b/.github/workflows/build_apk.yml
@@ -1,0 +1,37 @@
+name: Build APK
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: gradle
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+
+    - name: Grant execute permission for build script
+      run: chmod +x build_apk.sh
+
+    - name: Build with Gradle
+      run: ./build_apk.sh
+
+    - name: Upload APK
+      uses: actions/upload-artifact@v4
+      with:
+        name: Hexiano-debug
+        path: Hexiano/build/outputs/apk/debug/Hexiano-debug.apk

--- a/build_apk.sh
+++ b/build_apk.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+./gradlew assembleDebug


### PR DESCRIPTION
This PR introduces automation for building the Android APK.
- `build_apk.sh`: A helper script to build the debug APK locally.
- `.github/workflows/build_apk.yml`: A GitHub Action workflow that automatically builds the APK and uploads it as an artifact whenever changes are pushed to `master` or a pull request is opened.

---
*PR created automatically by Jules for task [3766328436319182639](https://jules.google.com/task/3766328436319182639) started by @lrq3000*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added continuous integration to automatically build and upload debug APK artifacts on pushes and pull requests to the master branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->